### PR TITLE
Drop HTTParty in flavor of Faraday

### DIFF
--- a/jeckle.gemspec
+++ b/jeckle.gemspec
@@ -18,9 +18,9 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'httparty'
-  spec.add_dependency 'virtus'
   spec.add_dependency 'activemodel', '>= 4.0'
+  spec.add_dependency 'faraday'
+  spec.add_dependency 'virtus'
 
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'rake'

--- a/lib/jeckle.rb
+++ b/lib/jeckle.rb
@@ -1,5 +1,5 @@
 require 'active_model'
-require 'httparty'
+require 'faraday'
 require 'virtus'
 
 require 'jeckle/version'

--- a/spec/jeckle/resource_spec.rb
+++ b/spec/jeckle/resource_spec.rb
@@ -3,9 +3,8 @@ require 'spec_helper'
 RSpec.describe Jeckle do
   subject(:fake_resource) { FakeResource.new }
 
-  it 'defines a response attribute' do
+  it 'defines a response attribute reader' do
     expect(fake_resource).to respond_to :response
-    expect(fake_resource).to respond_to :response=
   end
 
   it 'includes active_model/validations' do
@@ -19,6 +18,27 @@ RSpec.describe Jeckle do
   describe '.resource_name' do
     it 'returns snake case model name by default' do
       expect(FakeResource.resource_name).to eq 'fake_resource'
+    end
+  end
+
+  describe '.api' do
+    before { FakeResource.instance_variable_set(:@api, nil) }
+
+    let(:fake_faraday_connection) { Faraday::Connection.new }
+
+    it 'defines a Faraday api' do
+      expect(FakeResource.api).to be_kind_of Faraday::Connection
+    end
+
+    it 'caches the api' do
+      expect(Faraday).to receive(:new).once.and_return(fake_faraday_connection).with(url: 'http://myapi.com')
+      expect(fake_faraday_connection).to receive(:tap).once.and_call_original
+
+      10.times { FakeResource.api }
+    end
+
+    it 'assigns api_headers' do
+      expect(FakeResource.api.headers).to match 'Content-Type' => 'application/json'
     end
   end
 end


### PR DESCRIPTION
- Drop methods related with HTTParty
- Drop coupled #request method
  - The idea is to have a Request Object built from api connection and
    resource name

Solves #2
