### PR TITLE
URL gets namespace prepended when Jeckle::Resource is within a namespace

### DIFF
--- a/lib/jeckle/resource.rb
+++ b/lib/jeckle/resource.rb
@@ -9,7 +9,7 @@ module Jeckle
 
     module ClassMethods
       def resource_name
-        model_name.plural
+        model_name.element.pluralize
       end
 
       def default_api(registered_api_name)

--- a/spec/jeckle/resource_spec.rb
+++ b/spec/jeckle/resource_spec.rb
@@ -17,6 +17,17 @@ RSpec.describe Jeckle::Resource do
     it 'returns resource name based on class name' do
       expect(FakeResource.resource_name).to eq 'fake_resources'
     end
+
+    context 'when resource class is namespaced' do
+      before do
+        MySuperApi = Module.new
+        MySuperApi::FakeResource = Class.new(::FakeResource)
+      end
+
+      it 'ignores namespace' do
+        expect(MySuperApi::FakeResource.resource_name).to eq 'fake_resources'
+      end
+    end
   end
 
   describe '.api_mapping' do


### PR DESCRIPTION
Let's say I have this class:

``` ruby
module MyApi
  module Models
    module Car
      include Jeckle::Resource

      attribute :model
      attribute :color
      attribute :year
    end
  end
end
```

Whenever I try to find a car, the endpoint is generated with the namespace on it, e.g. `/my_api_models_cars/38`.

I think the ideal would be to not have the namespace prepended, like this: `/cars/38`.
