### PR TITLE
Add configurable timeout option to Jeckle::API

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Jeckle.configure do |config|
     }
     api.namespaces = { prefix: 'api', version: 'v1' }
     api.logger = Rails.logger
+    api.read_timeout = 5
   end
 end
 ```

--- a/lib/jeckle/api.rb
+++ b/lib/jeckle/api.rb
@@ -1,11 +1,11 @@
 module Jeckle
   class API
     attr_accessor :logger
-    attr_writer :base_uri, :namespaces, :params, :headers
-    attr_reader :basic_auth
+    attr_writer :base_uri, :namespaces, :params, :headers, :open_timeout, :read_timeout
+    attr_reader :basic_auth, :request_timeout
 
     def connection
-      @connection ||= Faraday.new(url: base_uri).tap do |conn|
+      @connection ||= Faraday.new(url: base_uri, request: timeout).tap do |conn|
         conn.headers = headers
         conn.params = params
         conn.response :logger, logger
@@ -43,6 +43,13 @@ module Jeckle
       raise Jeckle::ArgumentError, 'A block is required when configuring API middlewares' unless block_given?
 
       @middlewares_block = block
+    end
+
+    def timeout
+      {}.tap do |t|
+        t[:open_timeout] = @open_timeout if @open_timeout
+        t[:timeout] = @read_timeout if @read_timeout
+      end
     end
   end
 end

--- a/spec/fixtures/jeckle_config.rb
+++ b/spec/fixtures/jeckle_config.rb
@@ -1,28 +1,30 @@
 Jeckle::Setup.register(:my_super_api) do |api|
-  api.base_uri   = 'http://my-super-api.com.br'
-  api.headers    = { 'Content-Type' => 'application/json' }
-  api.logger     = Logger.new(STDOUT)
+  api.base_uri = 'http://my-super-api.com.br'
+  api.headers = { 'Content-Type' => 'application/json' }
+  api.logger = Logger.new(STDOUT)
   api.basic_auth = { username: 'steven_seagal', password: 'youAlwaysLose' }
   api.namespaces = { prefix: 'api', version: 'v1' }
-  api.params     = { hello: 'world' }
+  api.params = { hello: 'world' }
+  api.open_timeout = 2
+  api.read_timeout = 5
 
   api.middlewares do
-    request  :json
+    request :json
     response :json
     response :raise_error
   end
 end
 
 Jeckle::Setup.register(:another_api) do |api|
-  api.base_uri   = 'http://another-api.com.br'
-  api.headers    = { 'Content-Type' => 'application/json' }
-  api.logger     = Logger.new(STDOUT)
+  api.base_uri = 'http://another-api.com.br'
+  api.headers = { 'Content-Type' => 'application/json' }
+  api.logger = Logger.new(STDOUT)
   api.basic_auth = { username: 'heisenberg', password: 'metaAfetaAMina' }
   api.namespaces = { prefix: 'api', version: 'v5' }
-  api.params     = { hi: 'there' }
+  api.params = { hi: 'there' }
 
   api.middlewares do
-    request  :json
+    request :json
     response :json
     response :raise_error
   end


### PR DESCRIPTION
Pass open and read timeouts to Faraday connection ;)

``` ruby
Jeckle::Setup.register(:my_super_api) do |api|
  # ...
  api.open_timeout = 2
  api.read_timeout = 5
end

```
