### PR TITLE
Added example how to set up new APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ First, we need to configure our API:
 Jeckle.configure do |config|
   config.register :dribbble do |api|
     api.base_uri = 'http://api.dribbble.com'
+    api.middlewares do
+      response :json
+    end
   end
 end
 


### PR DESCRIPTION
- Instead of a theoretical example, I added Dribbble.com API example from the Example file together with detailed description on new API configuration, mapping and making some basic API calls.

This pull request fixes the issue #41.
