### PR TITLE
Allow attribute mapping from different api convention

### DIFF
--- a/lib/jeckle.rb
+++ b/lib/jeckle.rb
@@ -5,7 +5,7 @@ require 'virtus'
 
 require 'jeckle/version'
 
-%w(setup api model request http rest_actions resource errors).each do |file_name|
+%w(setup api model request http rest_actions resource errors mapping).each do |file_name|
   require "jeckle/#{file_name}"
 end
 

--- a/lib/jeckle/errors.rb
+++ b/lib/jeckle/errors.rb
@@ -26,4 +26,30 @@ module Jeckle
       super message
     end
   end
+
+  class InvalidAttributeMappingError < ::StandardError
+    def initialize(data)
+      class_name = data[:class_name]
+      resource_attribute = data[:resource_attribute]
+      api_attribute = data[:api_attribute]
+
+      message = %{Invalid attribute mapping: #{resource_attribute} => #{api_attribute}.
+
+        Heckle: - Hey chum, what we can do now?
+        Jeckle: - Old chap, you need to declare the #{resource_attribute} attribute.
+        Heckle: - Hey pal, then tell me how!
+        Jeckle: - Deal the trays, old thing:
+
+        class #{class_name}
+          attribute :#{resource_attribute}
+
+          mapping do
+            attribute :#{resource_attribute}, :#{api_attribute}
+          end
+        end
+      }
+
+      super message
+    end
+  end
 end

--- a/lib/jeckle/mapping.rb
+++ b/lib/jeckle/mapping.rb
@@ -13,20 +13,17 @@ module Jeckle
     end
 
     class AttributeMapping
-      def initialize(resource)
-        @resource = resource
+      def initialize(resource_class)
+        @resource_class = resource_class
       end
 
       def attribute(resource_attribute, api_attribute)
         raise Jeckle::InvalidAttributeMappingError,
-          { class_name: @resource.name, resource_attribute: resource_attribute,
+          { class_name: @resource_class.name, resource_attribute: resource_attribute,
             api_attribute: api_attribute
-        } unless @resource.attribute_set.map(&:name).include? resource_attribute
+        } unless @resource_class.attribute_set.map(&:name).include? resource_attribute
 
-        @resource.class_eval do
-          alias_method api_attribute, resource_attribute
-          alias_method "#{api_attribute}=", "#{resource_attribute}="
-        end
+        @resource_class.send(:alias_attribute, api_attribute, resource_attribute)
       end
     end
   end

--- a/lib/jeckle/mapping.rb
+++ b/lib/jeckle/mapping.rb
@@ -1,0 +1,30 @@
+module Jeckle
+  module Mapping
+    class CustomAttributeMapping
+      def initialize(resource)
+        @resource = resource
+      end
+
+      def attribute(resource_attribute, api_attribute)
+        raise Jeckle::InvalidAttributeMappingError,
+        { class_name: @resource.name, resource_attribute: resource_attribute,
+          api_attribute: api_attribute
+        } unless @resource.attribute_set.map(&:name).include? resource_attribute
+
+        @resource.send :define_method, api_attribute do
+          send(resource_attribute)
+        end
+
+        @resource.send :define_method, "#{api_attribute}=" do |value|
+          send("#{resource_attribute}=", value)
+        end
+      end
+    end
+
+    def mapping(&block)
+      @mapping ||= CustomAttributeMapping.new(self)
+
+      @mapping.instance_eval(&block) if block.present?
+    end
+  end
+end

--- a/lib/jeckle/mapping.rb
+++ b/lib/jeckle/mapping.rb
@@ -8,7 +8,7 @@ module Jeckle
       def mapping(&block)
         @mapping ||= AttributeMapping.new(self)
 
-        @mapping.instance_eval(&block) if block.present?
+        @mapping.instance_eval(&block) if block_given?
       end
     end
 

--- a/lib/jeckle/resource.rb
+++ b/lib/jeckle/resource.rb
@@ -6,6 +6,8 @@ module Jeckle
       base.send :include, Jeckle::Model
       base.send :include, Jeckle::HTTP
       base.send :include, Jeckle::RESTActions
+
+      base.send :extend, Jeckle::Mapping
     end
   end
 end

--- a/lib/jeckle/resource.rb
+++ b/lib/jeckle/resource.rb
@@ -7,7 +7,7 @@ module Jeckle
       base.send :include, Jeckle::HTTP
       base.send :include, Jeckle::RESTActions
 
-      base.send :extend, Jeckle::Mapping
+      base.send :include, Jeckle::CustomAttributeMapping
     end
   end
 end

--- a/spec/jeckle/mapping_spec.rb
+++ b/spec/jeckle/mapping_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+class CustomAttributeMappingResource
+  include Jeckle::Resource
+
+  attribute :first_name, String
+
+  mapping do
+    attribute :first_name, :FirstName
+  end
+end
+
+RSpec.describe Jeckle::CustomAttributeMapping do
+  let(:first_name) { 'First Name' }
+  let(:resource) { CustomAttributeMappingResource.new(FirstName: first_name) }
+
+  describe '#mapping' do
+    it 'initializes attributes by mapping options' do
+      expect(resource.first_name).to eq first_name
+    end
+  end
+end

--- a/spec/jeckle/resource_spec.rb
+++ b/spec/jeckle/resource_spec.rb
@@ -1,15 +1,5 @@
 require 'spec_helper'
 
-class CustomAttributeMappingResource
-  include Jeckle::Resource
-
-  attribute :first_name, String
-
-  mapping do
-    attribute :first_name, :FirstName
-  end
-end
-
 RSpec.describe Jeckle::Resource do
   subject(:fake_resource) { FakeResource.new }
 
@@ -29,10 +19,7 @@ RSpec.describe Jeckle::Resource do
     expect(FakeResource.ancestors).to include Jeckle::RESTActions
   end
 
-  describe 'custom attribute key mapping' do
-    it 'initializes attributes by key options' do
-      resource = CustomAttributeMappingResource.new(FirstName: 'First Name')
-      expect(resource.first_name).to eq('First Name')
-    end
+  it 'includes jeckle custom attribute mapping actions' do
+    expect(FakeResource.ancestors).to include Jeckle::CustomAttributeMapping
   end
 end

--- a/spec/jeckle/resource_spec.rb
+++ b/spec/jeckle/resource_spec.rb
@@ -1,5 +1,15 @@
 require 'spec_helper'
 
+class CustomAttributeMappingResource
+  include Jeckle::Resource
+
+  attribute :first_name, String
+
+  mapping do
+    attribute :first_name, :FirstName
+  end
+end
+
 RSpec.describe Jeckle::Resource do
   subject(:fake_resource) { FakeResource.new }
 
@@ -17,5 +27,12 @@ RSpec.describe Jeckle::Resource do
 
   it 'includes jeckle rest actions' do
     expect(FakeResource.ancestors).to include Jeckle::RESTActions
+  end
+
+  describe 'custom attribute key mapping' do
+    it 'initializes attributes by key options' do
+      resource = CustomAttributeMappingResource.new(FirstName: 'First Name')
+      expect(resource.first_name).to eq('First Name')
+    end
   end
 end


### PR DESCRIPTION
Sometimes the API don't return the json attributes as expected, so we need to allow the developer to map. 

I think this is a better approach than create alias because the resource keeps clean, containing just the attribute declaration and its properties.

PS: I don't know if this PR conflict with that issue #45.