### PR TITLE
Add flexibility to change the default resource_name in search method

### DIFF
--- a/lib/jeckle/rest_actions.rb
+++ b/lib/jeckle/rest_actions.rb
@@ -13,7 +13,9 @@ module Jeckle
       end
 
       def search(params = {})
-        response   = run_request(resource_name, params: params).response.body || []
+        custom_resource_name = params.delete(:resource_name) if params.kind_of?(Hash)
+
+        response   = run_request(custom_resource_name || resource_name, params: params).response.body || []
         collection = response.kind_of?(Array) ? response : response[resource_name]
 
         Array(collection).collect { |attrs| new attrs }

--- a/spec/lib/jeckle/rest_actions_spec.rb
+++ b/spec/lib/jeckle/rest_actions_spec.rb
@@ -69,5 +69,18 @@ RSpec.describe Jeckle::RESTActions do
         expect(FakeResource.search query).to match []
       end
     end
+
+    context 'when the endpoint is overwritten' do
+      let(:endpoint) { 'custom_endpoint' }
+      let(:query) { { resource_name: endpoint, name: 'cocada' } }
+      let(:body) { [{ id: 1001 }, { id: 1002 }] }
+
+      it 'calls default API connection with GET and search params' do
+        expect(Jeckle::Request).to receive(:run)
+          .with(api, endpoint, params: query).and_return(fake_request)
+
+        FakeResource.search query
+      end
+    end
   end
 end


### PR DESCRIPTION
Add flexibility to change the resource_name in Jeckle::RESTActions::Collection.search method.

Ex.
if we had:
`resource_name = 'resource_url'`

we could do:
`search(resouce_name: 'resource_url.json', param1: 'bla', param2: 'bla')`